### PR TITLE
Use stderr for all logging messages

### DIFF
--- a/src/sliding.c
+++ b/src/sliding.c
@@ -65,13 +65,13 @@ cutsites* sliding_window (kseq_t *fqrec, int qualtype, int length_threshold, int
 
 		window_avg = (double)window_total / (double)window_size;
 
-        if (debug) printf ("no_fiveprime: %d, found 5prime: %d, window_avg: %f\n", no_fiveprime, found_five_prime, window_avg);
+        if (debug) fprintf(stderr, "no_fiveprime: %d, found 5prime: %d, window_avg: %f\n", no_fiveprime, found_five_prime, window_avg);
 
 		/* Finding the 5' cutoff */
 		/* Find when the average quality in the window goes above the threshold starting from the 5' end */
 		if (no_fiveprime == 0 && found_five_prime == 0 && window_avg >= qual_threshold) {
 
-        if (debug) printf ("inside 5-prime cut\n");
+        if (debug) fprintf(stderr, "inside 5-prime cut\n");
 
 			/* at what point in the window does the quality go above the threshold? */
 			for (j=window_start; j<window_start+window_size; j++) {
@@ -81,7 +81,7 @@ cutsites* sliding_window (kseq_t *fqrec, int qualtype, int length_threshold, int
 				}
 			}
 
-            if (debug) printf ("five_prime_cut: %d\n", five_prime_cut);
+            if (debug) fprintf(stderr, "five_prime_cut: %d\n", five_prime_cut);
 
 			found_five_prime = 1;
 		}
@@ -125,10 +125,10 @@ cutsites* sliding_window (kseq_t *fqrec, int qualtype, int length_threshold, int
         three_prime_cut = -1;
         five_prime_cut = -1;
 
-        if (debug) printf("%s\n", fqrec->name.s);
+        if (debug) fprintf(stderr, "%s\n", fqrec->name.s);
     }
 
-    if (debug) printf ("\n\n");
+    if (debug) fprintf(stderr, "\n\n");
 
 	retvals = (cutsites*) malloc (sizeof(cutsites));
 	retvals->three_prime_cut = three_prime_cut;

--- a/src/trim_paired.c
+++ b/src/trim_paired.c
@@ -378,8 +378,8 @@ int paired_main(int argc, char *argv[]) {
         p2cut = sliding_window(fqrec2, qualtype, paired_length_threshold, paired_qual_threshold, no_fiveprime, trunc_n, debug);
         total += 2;
 
-        if (debug) printf("p1cut: %d,%d\n", p1cut->five_prime_cut, p1cut->three_prime_cut);
-        if (debug) printf("p2cut: %d,%d\n", p2cut->five_prime_cut, p2cut->three_prime_cut);
+        if (debug) fprintf(stderr, "p1cut: %d,%d\n", p1cut->five_prime_cut, p1cut->three_prime_cut);
+        if (debug) fprintf(stderr, "p2cut: %d,%d\n", p2cut->five_prime_cut, p2cut->three_prime_cut);
 
         /* The sequence and quality print statements below print out the sequence string starting from the 5' cut */
         /* and then only print out to the 3' cut, however, we need to adjust the 3' cut */
@@ -480,17 +480,17 @@ int paired_main(int argc, char *argv[]) {
     }
 
     if (!quiet) {
-        if (infn1 && infn2) fprintf(stdout, "\nPE forward file: %s\nPE reverse file: %s\n", infn1, infn2);
-        if (infnc) fprintf(stdout, "\nPE interleaved file: %s\n", infnc);
-        fprintf(stdout, "\nTotal input FastQ records: %d (%d pairs)\n", total, (total / 2));
-        fprintf(stdout, "\nFastQ paired records kept: %d (%d pairs)\n", kept_p, (kept_p / 2));
-        if (pec) fprintf(stdout, "FastQ single records kept: %d\n", (kept_s1 + kept_s2));
-        else fprintf(stdout, "FastQ single records kept: %d (from PE1: %d, from PE2: %d)\n", (kept_s1 + kept_s2), kept_s1, kept_s2);
+        if (infn1 && infn2) fprintf(stderr, "\nPE forward file: %s\nPE reverse file: %s\n", infn1, infn2);
+        if (infnc) fprintf(stderr, "\nPE interleaved file: %s\n", infnc);
+        fprintf(stderr, "\nTotal input FastQ records: %d (%d pairs)\n", total, (total / 2));
+        fprintf(stderr, "\nFastQ paired records kept: %d (%d pairs)\n", kept_p, (kept_p / 2));
+        if (pec) fprintf(stderr, "FastQ single records kept: %d\n", (kept_s1 + kept_s2));
+        else fprintf(stderr, "FastQ single records kept: %d (from PE1: %d, from PE2: %d)\n", (kept_s1 + kept_s2), kept_s1, kept_s2);
 
-        fprintf(stdout, "FastQ paired records discarded: %d (%d pairs)\n", discard_p, (discard_p / 2));
+        fprintf(stderr, "FastQ paired records discarded: %d (%d pairs)\n", discard_p, (discard_p / 2));
 
-        if (pec) fprintf(stdout, "FastQ single records discarded: %d\n\n", (discard_s1 + discard_s2));
-        else fprintf(stdout, "FastQ single records discarded: %d (from PE1: %d, from PE2: %d)\n\n", (discard_s1 + discard_s2), discard_s1, discard_s2);
+        if (pec) fprintf(stderr, "FastQ single records discarded: %d\n\n", (discard_s1 + discard_s2));
+        else fprintf(stderr, "FastQ single records discarded: %d (from PE1: %d, from PE2: %d)\n\n", (discard_s1 + discard_s2), discard_s1, discard_s2);
     }
 
     kseq_destroy(fqrec1);

--- a/src/trim_single.c
+++ b/src/trim_single.c
@@ -195,7 +195,7 @@ int single_main(int argc, char *argv[]) {
         p1cut = sliding_window(fqrec, qualtype, single_length_threshold, single_qual_threshold, no_fiveprime, trunc_n, debug);
         total++;
 
-        if (debug) printf("P1cut: %d,%d\n", p1cut->five_prime_cut, p1cut->three_prime_cut);
+        if (debug) fprintf(stderr, "P1cut: %d,%d\n", p1cut->five_prime_cut, p1cut->three_prime_cut);
 
         /* if sequence quality and length pass filter then output record, else discard */
         if (p1cut->three_prime_cut >= 0) {
@@ -217,7 +217,7 @@ int single_main(int argc, char *argv[]) {
         free(p1cut);
     }
 
-    if (!quiet) fprintf(stdout, "\nSE input file: %s\n\nTotal FastQ records: %d\nFastQ records kept: %d\nFastQ records discarded: %d\n\n", infn, total, kept, discard);
+    if (!quiet) fprintf(stderr, "\nSE input file: %s\n\nTotal FastQ records: %d\nFastQ records kept: %d\nFastQ records discarded: %d\n\n", infn, total, kept, discard);
 
     kseq_destroy(fqrec);
     gzclose(se);


### PR DESCRIPTION
Hi Nik,

We have been using sickle in a UNIX pipeline, and in some cases sickle prints logging or summary information to stdout, which ends up in with the fastq records. This PR simply changes all logging or debugging statements outside of `--help` and `--version` to use stderr, not stdout.
